### PR TITLE
deps: Remove ast dependencies

### DIFF
--- a/pyniryo/api/communication_functions.py
+++ b/pyniryo/api/communication_functions.py
@@ -3,7 +3,6 @@ File containing functions for communication with Socket !
 """
 
 import sys
-import ast
 import json
 import struct
 


### PR DESCRIPTION
This dependency is no longer used, but for some reason the last use of `ast` module was silently removed in this commit ca7ca87c 